### PR TITLE
remove ambiguous wording in assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The challenge is to make make analytical observations about the data using the d
 
 ## Processing & Analytical goals:
 
-1. Sessionize the web log by IP. Sessionize = aggregrate all page hits by visitor/IP during a fixed time window.
+1. Sessionize the web log by IP. Sessionize = aggregrate all page hits by visitor/IP during a session.
     https://en.wikipedia.org/wiki/Session_(web_analytics)
 
 2. Determine the average session time


### PR DESCRIPTION
fixed time window is ambiguous, and results in a lot of incorrect assignments.